### PR TITLE
can print the tweet sentence

### DIFF
--- a/twitter_scraping.rb
+++ b/twitter_scraping.rb
@@ -23,6 +23,10 @@ def get_next_json(min_position)
   # htmlの内容が崩れているので修正
   # \" -> "，\/ -> /，改行文字を改行するように再連結
   next_html = next_html.gsub(/\\u([\da-fA-F]{4})/) { [$1].pack('H*').unpack('n*').pack('U*') }
+  # 何故かUTF-8で怒られるのでencode
+  next_html = next_html.force_encoding('utf-8')
+  next_html = next_html.encode("utf-16be", "utf-8", :invalid => :replace, :undef => :replace, :replace => '?').encode("utf-8")
+
   revised_html = ""
   next_html.split('\n').each do |line|
     revised_html << line.gsub(%r{\\"|\\/}, '\"'=>'"', '\/'=>'/') << "\n"
@@ -33,10 +37,6 @@ end
 
 # htmlからtweet情報を取得
 def pull_out_tweet_data(html)
-  # 何故かUTF-8で怒られるのでencode
-  html = html.force_encoding('utf-8')
-  html = html.encode("utf-16be", "utf-8", :invalid => :replace, :undef => :replace, :replace => '?').encode("utf-8")
-
   # tweetのデータが入っているlistを正規表現で切り取り
   tweet_data = html.scan(%r{<li class="js-stream-item stream-item stream-item.+?\n\n</li>\n\n}m)
   tweet_data.each do |data|

--- a/twitter_scraping.rb
+++ b/twitter_scraping.rb
@@ -8,33 +8,50 @@ end
 
 # htmlを与えるとmin-positionを返す
 def get_min_position(top_html)
-  $1 if top_html =~ /data-min-position="(.+?)"/
+  top_html[/data-min-position="(.+?)"/, 1]
 end
 
 # min_positionからjsonを取得，次のmin_positionとhtmlに分割
 def get_next_json(min_position)
   url = "https://twitter.com/i/profiles/show/#{$account_name}/timeline/tweets?include_available_features=1&include_entities=1&max_position=#{min_position}&reset_error_state=false"
-  json_data = open(url)
-  p json_data.charset
+  json_data = open(url).read
 
   # 正規表現によりそれぞれを抜き出す
-  next_min = $1 if json_data =~ /"min_position":"(.+?)"/
-  next_html = $1 if json_data =~ /"items_html":"(.+?)","new_latent_count"/
+  next_min = json_data[/"min_position":"(.+?)"/, 1]
+  next_html = json_data[/"items_html":"(.+?)","new_latent_count"/, 1]
 
-  {"min_position" => next_min, "html" => next_html}
+  # htmlの内容が崩れているので修正
+  # \" -> "，\/ -> /，改行文字を改行するように再連結
+  next_html = next_html.gsub(/\\u([\da-fA-F]{4})/) { [$1].pack('H*').unpack('n*').pack('U*') }
+  revised_html = ""
+  next_html.split('\n').each do |line|
+    revised_html << line.gsub(%r{\\"|\\/}, '\"'=>'"', '\/'=>'/') << "\n"
+  end
+
+  {"min_position" => next_min, "html" => revised_html}
 end
 
 # htmlからtweet情報を取得
 def pull_out_tweet_data(html)
-  html = html.gsub(/\\u([\da-fA-F]{4})/) { [$1].pack('H*').unpack('n*').pack('U*') }
-  tweet_data = html.scan(%r{<li class=\"js-stream-item stream-item stream-item\n\".+?\n\n<\/li>\n\n})
-  # p tweet_data
+  # 何故かUTF-8で怒られるのでencode
+  html = html.force_encoding('utf-8')
+  html = html.encode("utf-16be", "utf-8", :invalid => :replace, :undef => :replace, :replace => '?').encode("utf-8")
+
+  # tweetのデータが入っているlistを正規表現で切り取り
+  tweet_data = html.scan(%r{<li class="js-stream-item stream-item stream-item.+?\n\n</li>\n\n}m)
+  tweet_data.each do |data|
+    # 仮実装，tweet本文と画像があればURLを取得して表示
+    puts "-"*100
+    puts data[%r{<div class="js-tweet-text-container">(.+?)</div>}m][%r{<p.+?>(.+?)</p>}m, 1]
+    puts
+  end
 end
 
 def main
   top_html = get_top_html
   min_position = get_min_position(top_html)
   next_data = get_next_json(min_position)
+  pull_out_tweet_data(top_html)
   pull_out_tweet_data(next_data["html"])
 end
 


### PR DESCRIPTION
## 内容
```https://twitter.com/アカウント名```で表示される画面内のTweetと，スクロールして一回目の更新で表示されるTweetまでの本文が表示できるようになりました．

## 実行
```ruby twitter_scraping [アカウント名(@付き，なければエラー文の表示で終了]```

## 今後
現在ではTweet本文のみなので，tweet日時を使った取得の制限やretweetは含まないなどのフィルタリングをする予定